### PR TITLE
Feature/etu 58 become instructor start teaching handle

### DIFF
--- a/app/instructor/dashboard/settings/page.tsx
+++ b/app/instructor/dashboard/settings/page.tsx
@@ -1,13 +1,26 @@
+import { getServerSession } from "next-auth";
+
 import AccountSettings from "@/components/instructor-dashboard/settings/AccountSettings";
 import Changepassword from "@/components/instructor-dashboard/settings/Changepassword";
 import Notifications from "@/components/instructor-dashboard/settings/Notifications";
 import SocialProfile from "@/components/instructor-dashboard/settings/SocialProfile";
+import { authOptions } from "@/lib/auth/authOptions";
+import { connectDB } from "@/lib/db/db";
+import instructorModel from "@/lib/db/models/instructorModel";
 
-const SettingsPage = () => {
+const SettingsPage = async () => {
+  await connectDB();
+
+  const session = await getServerSession(authOptions);
+
+  const foundInstructor = await instructorModel
+    .findOne({ user: session?.user.id })
+    .lean();
+  const plainInstructor = JSON.parse(JSON.stringify(foundInstructor));
   return (
     <section className="bg-base-200 space-y-6 p-6">
-      <AccountSettings />
-      <SocialProfile />
+      <AccountSettings instructor={plainInstructor} />
+      <SocialProfile instructor={plainInstructor} />
       <div className="container mx-auto grid grid-cols-1 gap-6 md:grid-cols-2">
         <Notifications />
         <Changepassword />

--- a/components/CourseCard.tsx
+++ b/components/CourseCard.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import React from "react";
 
 import { CourseTypes } from "@/app/page";
+
 import Icon from "./ui/Icon";
 
 interface Props {

--- a/components/Student/BecomeInstructorButton.tsx
+++ b/components/Student/BecomeInstructorButton.tsx
@@ -11,9 +11,10 @@ import { Student } from "./StudentProfile";
 type Props = {
   userId: string;
   student: Student;
+  isInstructor: boolean;
 };
 
-const BecomeInstructorButton = ({ userId, student }: Props) => {
+const BecomeInstructorButton = ({ userId, student, isInstructor }: Props) => {
   const [state, formAction, pending] = useActionState(becomeInstructor, {
     message: "",
     errors: [],
@@ -34,7 +35,7 @@ const BecomeInstructorButton = ({ userId, student }: Props) => {
     if (state.message === "ERROR") {
       setTimeout(() => {
         redirect("/instructor/dashboard");
-      }, 1000);
+      }, 500);
     }
   }, [state.message]);
 
@@ -45,7 +46,8 @@ const BecomeInstructorButton = ({ userId, student }: Props) => {
         className="btn btn-primary btn-soft mt-2 w-full gap-2 font-bold md:mt-0 md:ml-auto md:w-auto"
         disabled={pending}
       >
-        Become Instructor
+        {isInstructor ? "View Instructor Dashboard" : "Become Instructor"}
+
         {pending ? (
           <div className="loading loading-spinner" />
         ) : (
@@ -53,7 +55,7 @@ const BecomeInstructorButton = ({ userId, student }: Props) => {
         )}
       </button>
       {state.message === "ERROR" && (
-        <div className="text-error flex max-w-xs flex-row items-center gap-2 text-sm">
+        <div className="text-base-content/60 flex max-w-xs flex-row items-center gap-2 text-xs">
           <div className="loading loading-spinner" />
           {state.errors[0]}
         </div>

--- a/components/Student/BecomeInstructorButton.tsx
+++ b/components/Student/BecomeInstructorButton.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import React, { startTransition, useActionState, useEffect } from "react";
+import { redirect } from "next/navigation";
 
 import { becomeInstructor } from "@/lib/actions/becomeInstructor";
 
 import Icon from "../ui/Icon";
 import { Student } from "./StudentProfile";
-import { redirect } from "next/navigation";
 
 type Props = {
   userId: string;

--- a/components/Student/BecomeInstructorButton.tsx
+++ b/components/Student/BecomeInstructorButton.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import React, { startTransition, useActionState, useEffect } from "react";
+
+import { becomeInstructor } from "@/lib/actions/becomeInstructor";
+
+import Icon from "../ui/Icon";
+import { Student } from "./StudentProfile";
+import { redirect } from "next/navigation";
+
+type Props = {
+  userId: string;
+  student: Student;
+};
+
+const BecomeInstructorButton = ({ userId, student }: Props) => {
+  const [state, formAction, pending] = useActionState(becomeInstructor, {
+    message: "",
+    errors: [],
+  });
+
+  const becomeInstructorHandler = () => {
+    startTransition(() => {
+      const formData = new FormData();
+      formData.append("id", userId);
+      formData.append("firstname", student.firstname);
+      formData.append("lastname", student.lastname);
+
+      formAction(formData);
+    });
+  };
+
+  useEffect(() => {
+    if (state.message === "ERROR") {
+      setTimeout(() => {
+        redirect("/instructor/dashboard");
+      }, 1000);
+    }
+  }, [state.message]);
+
+  return (
+    <div className="flex flex-col justify-center gap-2">
+      <button
+        onClick={becomeInstructorHandler}
+        className="btn btn-primary btn-soft mt-2 w-full gap-2 font-bold md:mt-0 md:ml-auto md:w-auto"
+        disabled={pending}
+      >
+        Become Instructor
+        {pending ? (
+          <div className="loading loading-spinner" />
+        ) : (
+          <Icon icon="ph:arrow-right" className="text-xl sm:text-2xl" />
+        )}
+      </button>
+      {state.message === "ERROR" && (
+        <div className="text-error flex max-w-xs flex-row items-center gap-2 text-sm">
+          <div className="loading loading-spinner" />
+          {state.errors[0]}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default BecomeInstructorButton;

--- a/components/Student/StudentProfile.tsx
+++ b/components/Student/StudentProfile.tsx
@@ -8,6 +8,7 @@ import { redirect } from "next/navigation";
 import { authOptions } from "@/lib/auth/authOptions";
 import { connectDB } from "@/lib/db/db";
 import studentModel from "@/lib/db/models/studentModel";
+import instructorModel from "@/lib/db/models/instructorModel";
 
 import BecomeInstructorButton from "./BecomeInstructorButton";
 
@@ -34,6 +35,8 @@ const StudentProfile = async () => {
   if (!session?.user?.id) {
     return redirect("/auth/signin");
   }
+
+  const instructor = await instructorModel.findOne({ user: session.user.id });
 
   const student = await studentModel
     .findOne({ user: session.user.id })
@@ -73,6 +76,7 @@ const StudentProfile = async () => {
       <BecomeInstructorButton
         userId={session.user.id}
         student={JSON.parse(JSON.stringify(student))}
+        isInstructor={instructor ? true : false}
       />
     </div>
   );

--- a/components/Student/StudentProfile.tsx
+++ b/components/Student/StudentProfile.tsx
@@ -2,7 +2,6 @@
 
 import React from "react";
 import Image from "next/image";
-import { Icon } from "@iconify/react";
 import { getServerSession } from "next-auth";
 import { redirect } from "next/navigation";
 
@@ -10,7 +9,9 @@ import { authOptions } from "@/lib/auth/authOptions";
 import { connectDB } from "@/lib/db/db";
 import studentModel from "@/lib/db/models/studentModel";
 
-interface Student {
+import BecomeInstructorButton from "./BecomeInstructorButton";
+
+export interface Student {
   user: string;
   _id: string;
   bio: string;
@@ -69,10 +70,10 @@ const StudentProfile = async () => {
         </p>
       </div>
 
-      <button className="btn btn-primary btn-soft mt-2 w-full gap-2 font-bold md:mt-0 md:ml-auto md:w-auto">
-        Become Instructor
-        <Icon icon="ph:arrow-right" className="text-xl sm:text-2xl" />
-      </button>
+      <BecomeInstructorButton
+        userId={session.user.id}
+        student={JSON.parse(JSON.stringify(student))}
+      />
     </div>
   );
 };

--- a/components/instructor-dashboard/settings/AccountSettings.tsx
+++ b/components/instructor-dashboard/settings/AccountSettings.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { startTransition, useActionState, useEffect, useState } from "react";
+import { startTransition, useActionState, useState } from "react";
 import {
   CldImage,
   CldUploadButton,
@@ -39,8 +39,21 @@ const initialState = {
   errors: [],
 };
 
-const AccountSettings = () => {
-  const [title, setTitle] = useState<string>("");
+interface Props {
+  instructor: {
+    firstname: string;
+    lastname: string;
+    avatar: string;
+    username: string;
+    phoneCode: string;
+    phoneNumber: string;
+    title: string;
+    bio: string;
+  };
+}
+
+const AccountSettings = ({ instructor }: Props) => {
+  const [title, setTitle] = useState<string>(instructor?.title || "");
 
   const [state, formAction, pending] = useActionState(
     saveAccountSettings,
@@ -50,14 +63,18 @@ const AccountSettings = () => {
   const form = useForm<AccountSettingFormData>({
     resolver: zodResolver(accountSettingSchema),
     defaultValues: {
-      firstName: "",
-      lastName: "",
-      userName: "",
-      phoneCode: undefined,
-      phoneNumber: "",
-      title: "",
-      biography: "",
-      profile: "",
+      firstName: instructor?.firstname || "",
+      lastName: instructor?.lastname || "",
+      userName: instructor?.username || "",
+      phoneCode:
+        instructor.phoneCode &&
+        ["+87", "+880", "+98", "+95"].includes(instructor.phoneCode)
+          ? (instructor.phoneCode as "+87" | "+880" | "+98" | "+95")
+          : undefined,
+      phoneNumber: instructor?.phoneNumber || "",
+      title: title || "",
+      biography: instructor?.bio || "",
+      profile: instructor?.avatar || "",
     },
   });
 
@@ -71,13 +88,6 @@ const AccountSettings = () => {
       formAction(formData);
     });
   };
-
-  useEffect(() => {
-    if (state.message === "SUCCESS") {
-      form.reset();
-      setTitle("");
-    }
-  }, [state.message, form]);
 
   return (
     <section className="bg-base-100 container mx-auto p-6">

--- a/components/instructor-dashboard/settings/SocialProfile.tsx
+++ b/components/instructor-dashboard/settings/SocialProfile.tsx
@@ -26,7 +26,21 @@ const initialState = {
   errors: [],
 };
 
-const SocialProfile = () => {
+interface Props {
+  instructor: {
+    social: {
+      website: string;
+      facebook: string;
+      instagram: string;
+      linkedin: string;
+      youtube: string;
+      whatsapp: string;
+      twitter: string;
+    };
+  };
+}
+
+const SocialProfile = ({ instructor }: Props) => {
   const formFields = [
     {
       id: 1,
@@ -74,13 +88,13 @@ const SocialProfile = () => {
   const form = useForm<SocialProfileFormData>({
     resolver: zodResolver(socialProfileSchema),
     defaultValues: {
-      website: "",
-      facebook: "",
-      instagram: "",
-      linkedin: "",
-      twitter: "",
-      whatsapp: "",
-      youtube: "",
+      website: instructor.social.website || "",
+      facebook: instructor.social.facebook || "",
+      instagram: instructor.social.instagram || "",
+      linkedin: instructor.social.linkedin || "",
+      twitter: instructor.social.twitter || "",
+      whatsapp: instructor.social.whatsapp || "",
+      youtube: instructor.social.youtube || "",
     },
   });
 

--- a/lib/actions/becomeInstructor.ts
+++ b/lib/actions/becomeInstructor.ts
@@ -1,0 +1,47 @@
+"use server";
+
+import { redirect } from "next/navigation";
+import { getServerSession } from "next-auth";
+
+import instructorModel from "../db/models/instructorModel";
+import { ActionData } from "../formTypes";
+import { connectDB } from "../db/db";
+import { authOptions } from "../auth/authOptions";
+
+export async function becomeInstructor(
+  prevState: ActionData,
+  formData: FormData
+) {
+  await connectDB();
+
+  const data = Object.fromEntries(formData.entries());
+
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    redirect("/auth/signin");
+  }
+
+  const foundInstructor = await instructorModel.findOne({ user: data.id });
+
+  if (foundInstructor) {
+    return {
+      message: "ERROR",
+      errors: ["You are already a teacher. You are moving to the dashboard..."],
+    };
+  }
+
+  const newInstructor = await instructorModel.create({
+    user: data.id,
+    firstname: data.firstname,
+    lastname: data.lastname,
+  });
+
+  if (newInstructor) {
+    redirect("/instructor/dashboard/settings");
+  }
+
+  return {
+    message: "SUCCESS",
+    errors: [],
+  };
+}

--- a/lib/actions/becomeInstructor.ts
+++ b/lib/actions/becomeInstructor.ts
@@ -26,7 +26,7 @@ export async function becomeInstructor(
   if (foundInstructor) {
     return {
       message: "ERROR",
-      errors: ["You are already a teacher. You are moving to the dashboard..."],
+      errors: ["You are moving to the dashboard..."],
     };
   }
 

--- a/lib/actions/instructor/create-course/basicInformation.ts
+++ b/lib/actions/instructor/create-course/basicInformation.ts
@@ -2,6 +2,7 @@
 
 import { redirect } from "next/navigation";
 import { z } from "zod";
+import { getServerSession } from "next-auth";
 
 import { connectDB } from "@/lib/db/db";
 import categoryModel from "@/lib/db/models/categoryModel";
@@ -13,7 +14,6 @@ import {
   basicInformationSchema,
 } from "@/lib/validation/schemas/instructor/create-course";
 import { authOptions } from "@/lib/auth/authOptions";
-import { getServerSession } from "next-auth";
 import instructorModel from "@/lib/db/models/instructorModel";
 
 export async function saveBasicInformation(

--- a/lib/actions/instructor/create-course/basicInformation.ts
+++ b/lib/actions/instructor/create-course/basicInformation.ts
@@ -12,7 +12,9 @@ import {
   BasicInformationFormData,
   basicInformationSchema,
 } from "@/lib/validation/schemas/instructor/create-course";
-
+import { authOptions } from "@/lib/auth/authOptions";
+import { getServerSession } from "next-auth";
+import instructorModel from "@/lib/db/models/instructorModel";
 
 export async function saveBasicInformation(
   prevState: ActionData,
@@ -27,6 +29,11 @@ export async function saveBasicInformation(
       message: "ERROR",
       errors: result.error.errors.map((error) => error.message),
     };
+  }
+
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    redirect("/auth/signin");
   }
 
   // try {
@@ -49,17 +56,17 @@ export async function saveBasicInformation(
   }
 
   const durationValue = parseFloat(result.data.durationValue);
-  
+
   // Convert duration to hours
   let durationInHours: number;
   switch (result.data.durationUnit.toLowerCase()) {
-    case 'hour':
+    case "hour":
       durationInHours = durationValue;
       break;
-    case 'day':
+    case "day":
       durationInHours = durationValue * 24; // 1 day = 24 hours
       break;
-    case 'week':
+    case "week":
       durationInHours = durationValue * 24 * 7; // 1 week = 24 * 7 hours
       break;
     default:
@@ -80,25 +87,37 @@ export async function saveBasicInformation(
         language: result.data.language,
         subtitleLanguage: result.data.subtitleLang,
         level: result.data.level,
-        duration: durationInHours, // Save duration in hours
-        durationUnit: result.data.durationUnit, // Keep the original unit for reference
+        duration: durationInHours,
+        durationUnit: result.data.durationUnit,
       },
       { new: true }
     );
     return { message: "SUCCESS", errors: [] };
   } else {
+    const instructor = await instructorModel.findOne({
+      user: session?.user?.id,
+    });
+
     const createdCourse = await courseModel.create({
       title: result.data.title,
       subtitle: result.data.subtitle,
+      authors: [instructor._id],
       category: foundCategory._id,
       subCategory: foundSubCategory._id,
       topic: result.data.topic,
       language: result.data.language,
       subtitleLanguage: result.data.subtitleLang,
       level: result.data.level,
-      duration: durationInHours, // Save duration in hours
-      durationUnit: result.data.durationUnit, // Keep the original unit for reference
+      duration: durationInHours,
+      durationUnit: result.data.durationUnit,
     });
+
+    if (instructor) {
+      await instructorModel.findByIdAndUpdate(instructor._id, {
+        $push: { courses: createdCourse._id },
+      });
+    }
+
     redirect(
       `/instructor/dashboard/create-course?tab=AdvanceInformation&_id=${createdCourse._id}`
     );

--- a/lib/actions/instructor/settings/accountSettings.ts
+++ b/lib/actions/instructor/settings/accountSettings.ts
@@ -1,5 +1,10 @@
 "use server";
 
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "@/lib/auth/authOptions";
+import { connectDB } from "@/lib/db/db";
+import instructorModel from "@/lib/db/models/instructorModel";
 import { ActionData } from "@/lib/formTypes";
 import { accountSettingSchema } from "@/lib/validation/schemas/instructor/settings/accountSettings";
 
@@ -7,6 +12,8 @@ export async function saveAccountSettings(
   prevState: ActionData,
   formData: FormData
 ) {
+  await connectDB();
+
   const data = Object.fromEntries(formData.entries());
 
   const result = accountSettingSchema.safeParse(data);
@@ -17,10 +24,43 @@ export async function saveAccountSettings(
     };
   }
 
-  console.log(result.data);
+  const session = await getServerSession(authOptions);
 
-  return {
-    message: "SUCCESS",
-    errors: [],
-  };
+  const foundInstructor = await instructorModel.findOne({
+    user: session?.user.id,
+  });
+
+  if (!foundInstructor) {
+    return {
+      message: "ERROR",
+      errors: ["Instructor not found"],
+    };
+  }
+
+  try {
+    await instructorModel.findByIdAndUpdate(
+      foundInstructor._id,
+      {
+        firstname: result.data.firstName,
+        lastname: result.data.lastName,
+        avatar: result.data.profile,
+        username: result.data.userName,
+        phoneCode: result.data.phoneCode,
+        phoneNumber: result.data.phoneNumber,
+        title: result.data.title,
+        bio: result.data.biography,
+      },
+      { new: true }
+    );
+    return {
+      message: "SUCCESS",
+      errors: [],
+    };
+  } catch (error) {
+    console.log(error);
+    return {
+      message: "ERROR",
+      errors: ["save account settings error"],
+    };
+  }
 }

--- a/lib/actions/instructor/settings/socialProfile.ts
+++ b/lib/actions/instructor/settings/socialProfile.ts
@@ -1,5 +1,10 @@
 "use server";
 
+import { getServerSession } from "next-auth";
+
+import { authOptions } from "@/lib/auth/authOptions";
+import { connectDB } from "@/lib/db/db";
+import instructorModel from "@/lib/db/models/instructorModel";
 import { ActionData } from "@/lib/formTypes";
 import { socialProfileSchema } from "@/lib/validation/schemas/instructor/settings/socialProfile";
 
@@ -7,6 +12,8 @@ export async function saveSocialProfile(
   prevState: ActionData,
   formData: FormData
 ) {
+  await connectDB();
+
   const data = Object.fromEntries(formData.entries());
 
   const result = socialProfileSchema.safeParse(data);
@@ -17,7 +24,46 @@ export async function saveSocialProfile(
     };
   }
 
-  console.log(result.data);
+  const session = await getServerSession(authOptions);
+
+  const foundInstructor = await instructorModel.findOne({
+    user: session?.user.id,
+  });
+
+  if (!foundInstructor) {
+    return {
+      message: "ERROR",
+      errors: ["Instructor not found"],
+    };
+  }
+
+  try {
+    await instructorModel.findByIdAndUpdate(
+      foundInstructor._id,
+      {
+        social: {
+          website: result.data.website,
+          facebook: result.data.facebook,
+          instagram: result.data.instagram,
+          linkedin: result.data.linkedin,
+          youtube: result.data.youtube,
+          whatsapp: result.data.whatsapp,
+          twitter: result.data.twitter,
+        },
+      },
+      { new: true }
+    );
+    return {
+      message: "SUCCESS",
+      errors: [],
+    };
+  } catch (error) {
+    console.log(error);
+    return {
+      message: "ERROR",
+      errors: ["error in save social Profiles"],
+    };
+  }
 
   return {
     message: "SUCCESS",

--- a/lib/db/models/instructorModel.ts
+++ b/lib/db/models/instructorModel.ts
@@ -5,7 +5,10 @@ export interface InstructorInterface extends Document {
   lastname: string;
   avatar: string;
   username: string;
+  phoneCode: string;
+  phoneNumber: string;
   user: mongoose.Types.ObjectId;
+  title: string;
   bio: string;
   rating: number;
   students: number;
@@ -26,17 +29,21 @@ const instructorSchema = new Schema<InstructorInterface>(
     lastname: { type: String, required: true },
     avatar: { type: String, required: false },
     username: { type: String, required: true },
+    phoneCode: { type: String, required: true },
+    phoneNumber: { type: String, required: true },
     user: {
       type: Schema.Types.ObjectId,
       ref: "user",
       required: true,
       unique: true,
     },
+    title: { type: String, required: true },
     bio: { type: String, required: true },
-    rating: { type: Number, required: true, default: 0 },
-    students: { type: Number, required: true, default: 0 },
+    rating: { type: Number, required: false, default: 0 },
+    students: { type: Number, required: false, default: 0 },
     courses: [{ type: Schema.Types.ObjectId, ref: "course" }],
     social: {
+      website: { type: String, default: null },
       facebook: { type: String, default: null },
       instagram: { type: String, default: null },
       linkedin: { type: String, default: null },

--- a/lib/db/models/instructorModel.ts
+++ b/lib/db/models/instructorModel.ts
@@ -14,6 +14,7 @@ export interface InstructorInterface extends Document {
   students: number;
   courses: ObjectId[];
   social: {
+    website: string | null;
     facebook: string | null;
     instagram: string | null;
     linkedin: string | null;
@@ -25,22 +26,22 @@ export interface InstructorInterface extends Document {
 
 const instructorSchema = new Schema<InstructorInterface>(
   {
-    firstname: { type: String, required: true },
-    lastname: { type: String, required: true },
+    firstname: { type: String, required: false },
+    lastname: { type: String, required: false },
     avatar: { type: String, required: false },
-    username: { type: String, required: true },
-    phoneCode: { type: String, required: true },
-    phoneNumber: { type: String, required: true },
+    username: { type: String, required: false },
+    phoneCode: { type: String, required: false },
+    phoneNumber: { type: String, required: false },
     user: {
       type: Schema.Types.ObjectId,
       ref: "user",
       required: true,
       unique: true,
     },
-    title: { type: String, required: true },
-    bio: { type: String, required: true },
-    rating: { type: Number, required: false, default: 0 },
-    students: { type: Number, required: false, default: 0 },
+    title: { type: String, required: false },
+    bio: { type: String, required: false },
+    rating: { type: Number, required: true, default: 0 },
+    students: { type: Number, required: true, default: 0 },
     courses: [{ type: Schema.Types.ObjectId, ref: "course" }],
     social: {
       website: { type: String, default: null },


### PR DESCRIPTION
## Summary by Sourcery

Enable and streamline the instructor workflow by adding a 'Become Instructor' feature, persisting and preloading instructor settings, and linking course creation to instructor profiles

New Features:
- Add 'Become Instructor' flow with UI button and server action to create instructor profiles
- Prefill account and social profile forms in dashboard using authenticated instructor data
- Associate courses with authenticated instructors during basic course creation

Enhancements:
- Integrate database connection and session-based instructor lookups into saveAccountSettings, saveSocialProfile, and saveBasicInformation actions
- Extend instructor schema with optional phone code, phone number, title, biography and website fields