### PR TITLE
fix : curriculum open-close icon

### DIFF
--- a/components/Courses/watchCourses/WatchCurriculum.tsx
+++ b/components/Courses/watchCourses/WatchCurriculum.tsx
@@ -81,7 +81,6 @@ const WatchCurriculum = ({
               className="border-base-content/10 bg-base-100 border transition-all duration-150 hover:shadow-sm"
             >
               <AccordionTrigger className="px-4 py-3 hover:no-underline sm:px-6 sm:py-4">
-                  <Icon icon="ph:caret-down" className="text-xl text-primary" />
                 <div className="flex w-full flex-col gap-2 sm:flex-row sm:items-center sm:justify-between lg:flex-col lg:items-start xl:flex-row xl:justify-between">
                   <span className="text-base-content/80 text-base font-medium">
                     {section.title}

--- a/components/Student/student-wishlist/WishlistCoursesRow.tsx
+++ b/components/Student/student-wishlist/WishlistCoursesRow.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import Image from "next/image";
-import React from "react";
 
 import Icon from "@/components/ui/Icon";
 import WishlistBuyNow from "@/components/Student/student-wishlist/WishlistBuyNow";

--- a/components/ui/accordion.tsx
+++ b/components/ui/accordion.tsx
@@ -2,7 +2,7 @@
 
 import * as React from "react";
 import * as AccordionPrimitive from "@radix-ui/react-accordion";
-// import { ChevronDownIcon } from "lucide-react";
+import { ChevronDownIcon } from "lucide-react";
 
 import { cn } from "@/lib/utils";
 
@@ -40,8 +40,8 @@ function AccordionTrigger({
         )}
         {...props}
       >
+         <ChevronDownIcon className="pointer-events-none size-4 sm:size-6 shrink-0 translate-y-0.5 text-primary transition-transform duration-200 dark:text-neutral-400" />
         {children}
-        {/* <ChevronDownIcon className="pointer-events-none size-4 shrink-0 translate-y-0.5 text-neutral-500 transition-transform duration-200 dark:text-neutral-400" /> */}
       </AccordionPrimitive.Trigger>
     </AccordionPrimitive.Header>
   );


### PR DESCRIPTION
## Summary by Sourcery

Standardize curriculum accordion open/close indicator by replacing the custom caret icon with the ChevronDownIcon component and remove the deprecated Icon import.

Bug Fixes:
- Fix the incorrect curriculum open/close icon by introducing ChevronDownIcon in AccordionTrigger
- Remove the outdated caret-down Icon from the WatchCurriculum component

Enhancements:
- Update AccordionTrigger styling to use responsive sizing and transition classes for the new ChevronDownIcon